### PR TITLE
Add trait bound for std::error::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snapbox",
+ "thiserror",
 ]
 
 [[package]]
@@ -319,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73104609a7d865e4cd1de9cbf4e750683d076b6d0233bf81be511df274a26916"
 dependencies = [
  "hashbrown 0.14.5",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
  "num-bigint",
  "num-traits 0.2.19",
@@ -621,6 +622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,12 +673,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -986,7 +993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -1143,7 +1150,7 @@ version = "0.17.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719825638c59fd26a55412a24561c7c5bcf54364c88b9a7a04ba08a6eafaba8d"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "lock_api",
  "oorandom",
  "parking_lot",
@@ -1494,7 +1501,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 cairo-lang-sierra-to-casm = "2.8.2"
 cairo-lang-sierra = "2.8.2"
 camino = { version = "1.1.9", features = ["serde1"] }
+thiserror = "1.0.64"
 derive_more = { version = "1.0.0", features = ["add", "add_assign", "mul", "mul_assign"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.128"

--- a/crates/cairo-annotations/Cargo.toml
+++ b/crates/cairo-annotations/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 cairo-lang-sierra-to-casm.workspace = true
 cairo-lang-sierra.workspace = true
 camino.workspace = true
+thiserror.workspace = true
 derive_more.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cairo-annotations/src/annotations/traits.rs
+++ b/crates/cairo-annotations/src/annotations/traits.rs
@@ -1,8 +1,9 @@
 use cairo_lang_sierra::debug_info::DebugInfo;
 use serde::de::DeserializeOwned;
+use thiserror::Error;
 
 pub trait TryFromDebugInfo: Sized {
-    type Error;
+    type Error: std::error::Error;
 
     /// Attempt to create an instance of the implementing type from the provided sierra `DebugInfo`.
     /// # Errors
@@ -12,12 +13,15 @@ pub trait TryFromDebugInfo: Sized {
 }
 
 /// Enum representing the possible errors that can occur when trying to create an annotation from sierra debug information.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum AnnotationsError {
-    /// Error indicating that the namespace is missing from the annotations. Contains the missing namespace.
+    /// Error indicating that the namespace is missing from the annotations.
+    #[error("Missing namespace: {0}")]
     MissingNamespace(String),
-    /// Error indicating that the deserialization of the annotation failed. Contains the deserialization error.
-    DeserializationError(serde_json::Error),
+
+    /// Error indicating that the deserialization of the annotation failed.
+    #[error("Deserialization error: {0}")]
+    DeserializationError(#[from] serde_json::Error),
 }
 
 pub(crate) trait Namespace {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Add trait bound for std::error::Error so somebody can use `?` operator

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
