### PR TITLE
Wrap CallTraceV1 into Box for optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- Wrapped CallTraceV1 into Box for better performance
+

--- a/crates/cairo-annotations/src/trace_data.rs
+++ b/crates/cairo-annotations/src/trace_data.rs
@@ -50,7 +50,7 @@ pub struct CasmLevelInfo {
 /// Enum representing node of a trace of a call.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CallTraceNode {
-    EntryPointCall(CallTraceV1),
+    EntryPointCall(Box<CallTraceV1>),
     DeployWithoutConstructor,
 }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #21 

## Introduced changes

<!-- A brief description of the changes -->

- Fixed clippy warning for missing Box for CallTraceV1 (https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant)

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [] Updated relevant documentation
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
