### PR TITLE
Add GetClassHashAt to DeprecatedSyscallSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2024-11-27
+
+### Added
+
+- `GetClassHashAt` to `DeprecatedSyscallSelector` (introduced in starknet 0.13.3)
+
 ## [0.2.0] - 2024-11-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "cairo-annotations"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_fs",
  "cairo-lang-sierra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 authors = ["Software Mansion <contact@swmansion.com>"]

--- a/crates/cairo-annotations/src/trace_data.rs
+++ b/crates/cairo-annotations/src/trace_data.rs
@@ -136,6 +136,7 @@ pub enum DeprecatedSyscallSelector {
     GetBlockTimestamp,
     GetCallerAddress,
     GetContractAddress,
+    GetClassHashAt,
     GetExecutionInfo,
     GetSequencerAddress,
     GetTxInfo,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- Add newly introduced (0.13.3) GetClassHashAt to DeprecatedSyscallSelector needed by the profiler

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
