### PR TITLE
Add new fields to CallEntryPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2025-08-14
+
+### Added
+
+- new optional `signature_len` and `events_summary` fields to `CallEntryPoint`
+
 ## [0.5.0] - 2025-08-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "cairo-annotations"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_fs",
  "cairo-lang-sierra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 
 authors = ["Software Mansion <contact@swmansion.com>"]

--- a/crates/cairo-annotations/src/trace_data.rs
+++ b/crates/cairo-annotations/src/trace_data.rs
@@ -161,6 +161,12 @@ pub struct CallEntryPoint {
     /// Calldata length to use for syscall cost estimation
     /// Present for `snforge` >= `0.48.0`.
     pub calldata_len: Option<usize>,
+    /// Events information to use for l2 gas cost estimation
+    /// Present for `snforge` >= `0.49.0`
+    pub events_summary: Option<Vec<SummedUpEvent>>,
+    /// Signature length to use for l2 gas cost estimation
+    /// Present for `snforge` >= `0.49.0`
+    pub signature_len: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Deserialize, Serialize)]
@@ -264,4 +270,10 @@ impl SubAssign<&ExecutionResources> for ExecutionResources {
             self_counter.retain(|_, usage| usage.call_count > 0 || usage.linear_factor > 0);
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SummedUpEvent {
+    pub keys_len: usize,
+    pub data_len: usize,
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related to https://github.com/software-mansion/cairo-profiler/issues/91

## Introduced changes

<!-- A brief description of the changes -->

- add new optional `signature_len` and `events_summary` fields to `CallEntryPoint`, that are required for l2 gas estimations in profiler

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
