### PR TITLE
Allow setting custom header size in map_pcs_to_sierra_statement_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2025-09-29
+
+### Changed
+
+- Allow setting custom header size in `map_pcs_to_sierra_statement_ids`
+
+### Added
+
+- Optional fields to `CairoExecutionInfo`: `execute_target`, `not_returning_header_size` and `program_offset`
+
 ## [0.6.1] - 2025-09-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - 2025-09-29
+## [0.7.0] - 2025-10-07
 
 ### Changed
 
-- Allow setting custom header size in `map_pcs_to_sierra_statement_ids`
-
-### Added
-
-- Optional fields to `CairoExecutionInfo`: `execute_target`, `not_returning_header_size` and `program_offset`
+- Allow setting custom program offset in `map_pcs_to_sierra_statement_ids` (new optional field `program_offset` in `CasmLevelInfo`)
 
 ## [0.6.1] - 2025-09-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "cairo-annotations"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "assert_fs",
  "cairo-annotations",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 
 authors = ["Software Mansion <contact@swmansion.com>"]

--- a/crates/cairo-annotations/src/trace_data.rs
+++ b/crates/cairo-annotations/src/trace_data.rs
@@ -26,7 +26,7 @@ pub enum VersionedCallTrace {
 }
 
 /// Scarb execution target for the program.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ExecutionTarget {
     /// Bootloader target.
     Bootloader,

--- a/crates/cairo-annotations/src/trace_data.rs
+++ b/crates/cairo-annotations/src/trace_data.rs
@@ -25,6 +25,15 @@ pub enum VersionedCallTrace {
     V1(CallTraceV1),
 }
 
+/// Scarb execution target for the program.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ExecutionTarget {
+    /// Bootloader target.
+    Bootloader,
+    /// Standalone target.
+    Standalone,
+}
+
 /// Tree structure representing trace of a call.
 /// This struct should be serialized and used as an input to cairo-profiler.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,6 +54,12 @@ pub struct CairoExecutionInfo {
     pub casm_level_info: CasmLevelInfo,
     /// `enable-gas` option from [cairo] section in `Scarb.toml`
     pub enable_gas: Option<bool>,
+    /// Scarb execution target
+    pub execute_target: Option<ExecutionTarget>,
+    /// Size of a non-returning header in executable target
+    pub not_returning_header_size: Option<usize>,
+    /// Executable program offset information
+    pub program_offset: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/cairo-annotations/src/trace_data.rs
+++ b/crates/cairo-annotations/src/trace_data.rs
@@ -25,15 +25,6 @@ pub enum VersionedCallTrace {
     V1(CallTraceV1),
 }
 
-/// Scarb execution target for the program.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum ExecutionTarget {
-    /// Bootloader target.
-    Bootloader,
-    /// Standalone target.
-    Standalone,
-}
-
 /// Tree structure representing trace of a call.
 /// This struct should be serialized and used as an input to cairo-profiler.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -54,18 +45,14 @@ pub struct CairoExecutionInfo {
     pub casm_level_info: CasmLevelInfo,
     /// `enable-gas` option from [cairo] section in `Scarb.toml`
     pub enable_gas: Option<bool>,
-    /// Scarb execution target
-    pub execute_target: Option<ExecutionTarget>,
-    /// Size of a non-returning header in executable target
-    pub not_returning_header_size: Option<usize>,
-    /// Executable program offset information
-    pub program_offset: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CasmLevelInfo {
     pub run_with_call_header: bool,
     pub vm_trace: Vec<TraceEntry>,
+    /// Executable program offset information
+    pub program_offset: Option<usize>,
 }
 
 /// Enum representing node of a trace of a call.

--- a/crates/cairo-annotations/tests/integration/map_pcs_to_sierra_statement_ids.rs
+++ b/crates/cairo-annotations/tests/integration/map_pcs_to_sierra_statement_ids.rs
@@ -9,6 +9,7 @@ fn test_happy_path() {
     let output = map_pcs_to_sierra_statement_ids(
         &SCARB_TEMPLATE_TRACE_FILE.get_casm_debug_info(),
         SCARB_TEMPLATE_TRACE_FILE.get_casm_level_info(),
+        None,
     );
 
     output.assert_same_as_in_file("map_pcs.txt");
@@ -21,6 +22,7 @@ fn test_empty_sierra_statement_info() {
             sierra_statement_info: Vec::new(),
         },
         SCARB_TEMPLATE_TRACE_FILE.get_casm_level_info(),
+        None,
     );
 
     assert!(output.is_empty());
@@ -36,6 +38,7 @@ fn test_empty_vm_trace() {
                 .get_casm_level_info()
                 .run_with_call_header,
         },
+        None,
     );
 
     assert!(output.is_empty());

--- a/crates/cairo-annotations/tests/integration/map_pcs_to_sierra_statement_ids.rs
+++ b/crates/cairo-annotations/tests/integration/map_pcs_to_sierra_statement_ids.rs
@@ -9,7 +9,6 @@ fn test_happy_path() {
     let output = map_pcs_to_sierra_statement_ids(
         &SCARB_TEMPLATE_TRACE_FILE.get_casm_debug_info(),
         SCARB_TEMPLATE_TRACE_FILE.get_casm_level_info(),
-        None,
     );
 
     output.assert_same_as_in_file("map_pcs.txt");
@@ -22,7 +21,6 @@ fn test_empty_sierra_statement_info() {
             sierra_statement_info: Vec::new(),
         },
         SCARB_TEMPLATE_TRACE_FILE.get_casm_level_info(),
-        None,
     );
 
     assert!(output.is_empty());
@@ -37,8 +35,8 @@ fn test_empty_vm_trace() {
             run_with_call_header: SCARB_TEMPLATE_TRACE_FILE
                 .get_casm_level_info()
                 .run_with_call_header,
+            program_offset: None,
         },
-        None,
     );
 
     assert!(output.is_empty());


### PR DESCRIPTION

## Introduced changes

<!-- A brief description of the changes -->

- Allows setting custom header size in map_pcs_to_sierra_statement_ids
- Adds new optional fields to TraceData

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
