### PR TITLE
Ignore `cairo-lang-*`deps for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       regular:
         exclude-patterns:
           - "cairo-lang-*"
-      cairo-lang:
-        patterns:
-          - "cairo-lang-*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
We should keep them in the lowest possible version (unless API changes in minors happen ofc) for compatibility of this library with crates using different compiler versions. Example: #126