### PR TITLE
Downgrade `starknet-types-core` and ignore it in `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       regular:
         exclude-patterns:
           - "cairo-lang-*"
+          - "starknet-types-core"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Downgraded `starknet-types-core` dependency
+
 ## [0.9.0] - 2026-06-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snapbox",
- "starknet-types-core 1.0.0",
+ "starknet-types-core",
  "strum",
  "strum_macros",
  "thiserror",
@@ -269,7 +269,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror",
 ]
 
@@ -322,7 +322,7 @@ dependencies = [
  "itertools",
  "num-bigint",
  "num-traits",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror",
 ]
 
@@ -1700,23 +1700,6 @@ dependencies = [
  "lambdaworks-crypto",
  "lambdaworks-math",
  "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits",
- "rand 0.9.2",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-types-core"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a12690813e587969cb4a9e7d8ebdb069d4bb7ec8d03275c5f719310c8e1f07c"
-dependencies = [
- "generic-array",
- "lambdaworks-crypto",
- "lambdaworks-math",
  "num-bigint",
  "num-integer",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/software-mansion/cairo-annotations"
 cairo-lang-sierra-to-casm = "2.17.0-rc.4"
 cairo-lang-sierra = "2.17.0-rc.4"
 cairo-lang-sierra-type-size = "2.17.0-rc.4"
-starknet-types-core = "1.0.0"
+starknet-types-core = "0.2.4"
 camino = { version = "1.2.2", features = ["serde1"] }
 thiserror = "2.0.18"
 derive_more = { version = "2.1.1", features = ["add", "add_assign", "mul", "mul_assign", "display"] }


### PR DESCRIPTION
## Introduced changes

- self explanatory. We need to do that since important packages in the ecosystem cannot be arsed to upgrade it e.g. blockifier depends on `starknet-types-core` 0.2.4, therefore `snforge` cannot use `cairo-annotations` 0.9.0

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
